### PR TITLE
Support adding HTTP headers to requests

### DIFF
--- a/kong/config.go
+++ b/kong/config.go
@@ -8,8 +8,15 @@ type Config struct {
 	Address string
 	Username string
 	Password string
+	Headers map[string]interface{}
 }
 
 func (c *Config) Client() (*sling.Sling, error) {
-	return sling.New().SetBasicAuth(c.Username, c.Password).Base(c.Address), nil
+	client := sling.New().SetBasicAuth(c.Username, c.Password).Base(c.Address)
+
+	for key, value := range c.Headers {
+    client.Set(key, value.(string))
+	}
+
+	return client, nil
 }

--- a/kong/config.go
+++ b/kong/config.go
@@ -8,14 +8,14 @@ type Config struct {
 	Address string
 	Username string
 	Password string
-	Headers map[string]interface{}
+	Headers  map[string]interface{}
 }
 
 func (c *Config) Client() (*sling.Sling, error) {
 	client := sling.New().SetBasicAuth(c.Username, c.Password).Base(c.Address)
 
 	for key, value := range c.Headers {
-    client.Set(key, value.(string))
+		client.Set(key, value.(string))
 	}
 
 	return client, nil

--- a/kong/resource_provider.go
+++ b/kong/resource_provider.go
@@ -25,8 +25,8 @@ func Provider() terraform.ResourceProvider {
 			},
 			"headers": &schema.Schema{
 				Type:     schema.TypeMap,
-				Optional:    true,
-				Default: nil,
+				Optional: true,
+				Default:  nil,
 			},
 		},
 
@@ -51,7 +51,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Address: d.Get("address").(string),
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
-		Headers: d.Get("headers").(map[string]interface{}),
+		Headers:  d.Get("headers").(map[string]interface{}),
 	}
 
 	return config.Client()

--- a/kong/resource_provider.go
+++ b/kong/resource_provider.go
@@ -23,6 +23,11 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				Default: "",
 			},
+			"headers": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional:    true,
+				Default: nil,
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -46,6 +51,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Address: d.Get("address").(string),
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
+		Headers: d.Get("headers").(map[string]interface{}),
 	}
 
 	return config.Client()


### PR DESCRIPTION
Add a "headers" key to the resource provider configuration. Any items in this Map will be to any requests to the kong admin api.

# Motivation
Some people may be running the Kong API with auth other than basic.