### PR TITLE
Display json error response on unexpected HTTP status codes

### DIFF
--- a/kong/error_response.go
+++ b/kong/error_response.go
@@ -6,11 +6,8 @@ import (
 	"net/http"
 )
 
-type ErrorResponse map[string]interface {
-}
-
-func ErrorFromResponse(response *http.Response, errorResponse *ErrorResponse) error {
-	bytes, err := json.Marshal(errorResponse)
+func ErrorFromResponse(response *http.Response, errorResponse *map[string]interface{}) error {
+	bytes, err := json.MarshalIndent(errorResponse, "", "  ")
 	if err != nil {
 		return fmt.Errorf("unexpected status (%v) received: %v", response.Status, errorResponse)
 	} else {

--- a/kong/error_response.go
+++ b/kong/error_response.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func ErrorFromResponse(response *http.Response, errorResponse *map[string]interface{}) error {
+func ErrorFromResponse(response *http.Response, errorResponse map[string]interface{}) error {
 	bytes, err := json.MarshalIndent(errorResponse, "", "  ")
 	if err != nil {
 		return fmt.Errorf("unexpected status (%v) received: %v", response.Status, errorResponse)

--- a/kong/error_response.go
+++ b/kong/error_response.go
@@ -1,0 +1,19 @@
+package kong
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type ErrorResponse map[string]interface {
+}
+
+func ErrorFromResponse(response *http.Response, errorResponse *ErrorResponse) error {
+	bytes, err := json.Marshal(errorResponse)
+	if err != nil {
+		return fmt.Errorf("unexpected status (%v) received: %v", response.Status, errorResponse)
+	} else {
+		return fmt.Errorf("unexpected status (%v) received: %v", response.Status, string(bytes))
+	}
+}

--- a/kong/resource_kong_api.go
+++ b/kong/resource_kong_api.go
@@ -163,7 +163,7 @@ func resourceKongAPICreate(d *schema.ResourceData, meta interface{}) error {
 	api := getAPIFromResourceData(d)
 
 	createdAPI := new(APIResponse)
-	errorResponse := new(ErrorResponse)
+	errorResponse := make(map[string]interface{})
 	response, error := sling.New().BodyJSON(api).Post("apis/").Receive(createdAPI, errorResponse)
 
 	if error != nil {
@@ -187,7 +187,7 @@ func resourceKongAPIRead(d *schema.ResourceData, meta interface{}) error {
 	id := d.Get("id").(string)
 	api := new(APIResponse)
 
-	errorResponse := new(ErrorResponse)
+	errorResponse := make(map[string]interface{})
 	response, error := sling.New().Path("apis/").Get(id).Receive(api, errorResponse)
 
 	if error != nil {
@@ -212,7 +212,7 @@ func resourceKongAPIUpdate(d *schema.ResourceData, meta interface{}) error {
 	api := getAPIFromResourceData(d)
 
 	updatedAPI := new(APIResponse)
-	errorResponse := new(ErrorResponse)
+	errorResponse := make(map[string]interface{})
 	response, error := sling.New().BodyJSON(api).Patch("apis/").Path(api.ID).Receive(updatedAPI, errorResponse)
 
 	if error != nil {
@@ -233,7 +233,7 @@ func resourceKongAPIDelete(d *schema.ResourceData, meta interface{}) error {
 
 	id := d.Get("id").(string)
 
-	errorResponse := new(ErrorResponse)
+	errorResponse := make(map[string]interface{})
 	response, error := sling.New().Delete("apis/").Path(id).Receive(nil, errorResponse)
 	if error != nil {
 		return fmt.Errorf("error while deleting API: %v", error.Error())

--- a/kong/resource_kong_consumer.go
+++ b/kong/resource_kong_consumer.go
@@ -55,7 +55,8 @@ func resourceKongConsumerCreate(d *schema.ResourceData, meta interface{}) error 
 
 	createdConsumer := new(Consumer)
 
-	response, error := sling.New().BodyJSON(consumer).Post("consumers/").ReceiveSuccess(createdConsumer)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(consumer).Post("consumers/").Receive(createdConsumer, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while creating consumer.")
 	}
@@ -63,7 +64,7 @@ func resourceKongConsumerCreate(d *schema.ResourceData, meta interface{}) error 
 	if response.StatusCode == http.StatusConflict {
 		return fmt.Errorf("409 Conflict - use terraform import to manage this consumer.")
 	} else if response.StatusCode != http.StatusCreated {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setConsumerToResourceData(d, createdConsumer)
@@ -77,7 +78,8 @@ func resourceKongConsumerRead(d *schema.ResourceData, meta interface{}) error {
 	id := d.Get("id").(string)
 	consumer := new(Consumer)
 
-	response, error := sling.New().Path("consumers/").Get(id).ReceiveSuccess(consumer)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Get(id).Receive(consumer, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating consumer.")
 	}
@@ -86,7 +88,7 @@ func resourceKongConsumerRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	} else if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setConsumerToResourceData(d, consumer)
@@ -101,13 +103,14 @@ func resourceKongConsumerUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	updatedConsumer := new(Consumer)
 
-	response, error := sling.New().BodyJSON(consumer).Patch("consumers/").Path(consumer.ID).ReceiveSuccess(updatedConsumer)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(consumer).Patch("consumers/").Path(consumer.ID).Receive(updatedConsumer, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating consumer.")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setConsumerToResourceData(d, updatedConsumer)
@@ -120,13 +123,14 @@ func resourceKongConsumerDelete(d *schema.ResourceData, meta interface{}) error 
 
 	id := d.Get("id").(string)
 
-	response, error := sling.New().Delete("consumers/").Path(id).ReceiveSuccess(nil)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Delete("consumers/").Path(id).Receive(nil, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while deleting consumer.")
 	}
 
 	if response.StatusCode != http.StatusNoContent {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	return nil

--- a/kong/resource_kong_consumer_acl.go
+++ b/kong/resource_kong_consumer_acl.go
@@ -67,7 +67,7 @@ func resourceKongConsumerACLCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if response.StatusCode == http.StatusBadRequest {
-		return fmt.Errorf("%v - %v; use `terraform import %s/%s` to manage this resource with terraform.", resource.Status, errorResponse["group"], consumer, createRequest.Group)
+		return fmt.Errorf("%v - %v; use `terraform import %s/%s` to manage this resource with terraform.", response.Status, errorResponse["group"], consumer, createRequest.Group)
 	} else if response.StatusCode != http.StatusCreated {
 		return ErrorFromResponse(response, errorResponse)
 	}
@@ -120,7 +120,7 @@ func resourceKongConsumerACLUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if response.StatusCode == http.StatusBadRequest {
-		return fmt.Errorf("%v - %v; use `terraform import %v/%v` to manage this resource with terraform.", resource.Status, errorResponse["group"], consumer, updateRequest.Group)
+		return fmt.Errorf("%v - %v; use `terraform import %v/%v` to manage this resource with terraform.", response.Status, errorResponse["group"], consumer, updateRequest.Group)
 	} else if response.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil

--- a/kong/resource_kong_consumer_acl.go
+++ b/kong/resource_kong_consumer_acl.go
@@ -60,16 +60,16 @@ func resourceKongConsumerACLCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	consumer := d.Get("consumer").(string)
 	updated := &ConsumerACL{}
-	failure := &UpdateAclRequest{}
-	response, error := sling.New().BodyJSON(createRequest).Path("consumers/").Path(consumer+"/").Post("acls/").Receive(updated, failure)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(createRequest).Path("consumers/").Path(consumer+"/").Post("acls/").Receive(updated, errorResponse)
 	if error != nil {
 		return fmt.Errorf("error while creating ACL" + error.Error())
 	}
 
 	if response.StatusCode == http.StatusBadRequest {
-		return fmt.Errorf(response.Status + " - " + failure.Group + "; use `terraform import <consumer>/<acl>` to manage this resource with terraform.")
+		return fmt.Errorf("%v - %v; use `terraform import %s/%s` to manage this resource with terraform.", resource.Status, errorResponse["group"], consumer, createRequest.Group)
 	} else if response.StatusCode != http.StatusCreated {
-		return fmt.Errorf("unexpected status code received: " + response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	d.Set("consumer", updated.Consumer)
@@ -84,7 +84,8 @@ func resourceKongConsumerACLRead(d *schema.ResourceData, meta interface{}) error
 
 	consumer := d.Get("consumer").(string)
 	updated := &ConsumerACL{}
-	response, error := sling.New().Path("consumers/").Path(consumer + "/").Path("acls/").Get(d.Id()).ReceiveSuccess(updated)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(consumer+"/").Path("acls/").Get(d.Id()).Receive(updated, errorResponse)
 	if error != nil {
 		return fmt.Errorf("error while reading ACL" + error.Error())
 	}
@@ -93,7 +94,7 @@ func resourceKongConsumerACLRead(d *schema.ResourceData, meta interface{}) error
 		d.SetId("")
 		return nil
 	} else if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code received: " + response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	d.Set("consumer", updated.Consumer)
@@ -112,19 +113,19 @@ func resourceKongConsumerACLUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 	consumer := d.Get("consumer").(string)
 	updated := &ConsumerACL{}
-	failure := &UpdateAclRequest{}
-	response, error := sling.New().BodyJSON(updateRequest).Path("consumers/").Path(consumer+"/").Path("acls/").Patch(d.Id()).Receive(updated, failure)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(updateRequest).Path("consumers/").Path(consumer+"/").Path("acls/").Patch(d.Id()).Receive(updated, errorResponse)
 	if error != nil {
 		return fmt.Errorf("error while creating ACL" + error.Error())
 	}
 
 	if response.StatusCode == http.StatusBadRequest {
-		return fmt.Errorf(response.Status + " - " + failure.Group + "; use `terraform import <consumer>/<acl>` to manage this resource with terraform.")
+		return fmt.Errorf("%v - %v; use `terraform import %v/%v` to manage this resource with terraform.", resource.Status, errorResponse["group"], consumer, updateRequest.Group)
 	} else if response.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
 	} else if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code received: " + response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	d.Set("consumer", updated.Consumer)
@@ -138,14 +139,15 @@ func resourceKongConsumerACLDelete(d *schema.ResourceData, meta interface{}) err
 	sling := meta.(*sling.Sling)
 
 	consumer := d.Get("consumer").(string)
-	response, error := sling.New().Path("consumers/").Path(consumer + "/").Path("acls/").Delete(d.Id()).ReceiveSuccess(nil)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(consumer+"/").Path("acls/").Delete(d.Id()).Receive(nil, errorResponse)
 
 	if error != nil {
 		return fmt.Errorf("error while deleting ACL" + error.Error())
 	}
 
 	if response.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code received: " + response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	return nil

--- a/kong/resource_kong_consumer_credential_basic_auth.go
+++ b/kong/resource_kong_consumer_credential_basic_auth.go
@@ -61,13 +61,14 @@ func resourceKongBasicAuthCredentialCreate(d *schema.ResourceData, meta interfac
 
 	createdBasicAuthCredential := getBasicAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(basicAuthCredential).Path("consumers/").Path(basicAuthCredential.Consumer + "/").Post("basic-auth/").ReceiveSuccess(createdBasicAuthCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(basicAuthCredential).Path("consumers/").Path(basicAuthCredential.Consumer+"/").Post("basic-auth/").Receive(createdBasicAuthCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while creating basicAuthCredential.")
 	}
 
 	if response.StatusCode != http.StatusCreated {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setBasicAuthCredentialToResourceData(d, createdBasicAuthCredential)
@@ -80,7 +81,8 @@ func resourceKongBasicAuthCredentialRead(d *schema.ResourceData, meta interface{
 
 	basicAuthCredential := getBasicAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().Path("consumers/").Path(basicAuthCredential.Consumer + "/").Path("basic-auth/").Get(basicAuthCredential.ID).ReceiveSuccess(basicAuthCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(basicAuthCredential.Consumer+"/").Path("basic-auth/").Get(basicAuthCredential.ID).Receive(basicAuthCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating basicAuthCredential.")
 	}
@@ -89,7 +91,7 @@ func resourceKongBasicAuthCredentialRead(d *schema.ResourceData, meta interface{
 		d.SetId("")
 		return nil
 	} else if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setBasicAuthCredentialToResourceData(d, basicAuthCredential)
@@ -104,13 +106,14 @@ func resourceKongBasicAuthCredentialUpdate(d *schema.ResourceData, meta interfac
 
 	updatedBasicAuthCredential := getBasicAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(basicAuthCredential).Path("consumers/").Path(basicAuthCredential.Consumer + "/").Patch("basic-auth/").Path(basicAuthCredential.ID).ReceiveSuccess(updatedBasicAuthCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(basicAuthCredential).Path("consumers/").Path(basicAuthCredential.Consumer+"/").Patch("basic-auth/").Path(basicAuthCredential.ID).Receive(updatedBasicAuthCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating basicAuthCredential.")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setBasicAuthCredentialToResourceData(d, updatedBasicAuthCredential)
@@ -123,13 +126,14 @@ func resourceKongBasicAuthCredentialDelete(d *schema.ResourceData, meta interfac
 
 	basicAuthCredential := getBasicAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().Path("consumers/").Path(basicAuthCredential.Consumer + "/").Path("basic-auth/").Delete(basicAuthCredential.ID).ReceiveSuccess(nil)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(basicAuthCredential.Consumer+"/").Path("basic-auth/").Delete(basicAuthCredential.ID).Receive(nil, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while deleting basicAuthCredential.")
 	}
 
 	if response.StatusCode != http.StatusNoContent {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	return nil

--- a/kong/resource_kong_consumer_credential_jwt.go
+++ b/kong/resource_kong_consumer_credential_jwt.go
@@ -78,13 +78,14 @@ func resourceKongJWTCredentialCreate(d *schema.ResourceData, meta interface{}) e
 
 	createdJWTCredential := getJWTCredentialFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(jwtCredential).Path("consumers/").Path(jwtCredential.Consumer + "/").Post("jwt/").ReceiveSuccess(createdJWTCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(jwtCredential).Path("consumers/").Path(jwtCredential.Consumer+"/").Post("jwt/").Receive(createdJWTCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while creating jwtCredential.")
 	}
 
 	if response.StatusCode != http.StatusCreated {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setJWTCredentialToResourceData(d, createdJWTCredential)
@@ -97,7 +98,8 @@ func resourceKongJWTCredentialRead(d *schema.ResourceData, meta interface{}) err
 
 	jwtCredential := getJWTCredentialFromResourceData(d)
 
-	response, error := sling.New().Path("consumers/").Path(jwtCredential.Consumer + "/").Path("jwt/").Get(jwtCredential.ID).ReceiveSuccess(jwtCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(jwtCredential.Consumer+"/").Path("jwt/").Get(jwtCredential.ID).Receive(jwtCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating jwtCredential.")
 	}
@@ -106,7 +108,7 @@ func resourceKongJWTCredentialRead(d *schema.ResourceData, meta interface{}) err
 		d.SetId("")
 		return nil
 	} else if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setJWTCredentialToResourceData(d, jwtCredential)
@@ -121,13 +123,14 @@ func resourceKongJWTCredentialUpdate(d *schema.ResourceData, meta interface{}) e
 
 	updatedJWTCredential := getJWTCredentialFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(jwtCredential).Path("consumers/").Path(jwtCredential.Consumer + "/").Patch("jwt/").Path(jwtCredential.ID).ReceiveSuccess(updatedJWTCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(jwtCredential).Path("consumers/").Path(jwtCredential.Consumer+"/").Patch("jwt/").Path(jwtCredential.ID).Receive(updatedJWTCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating jwtCredential.")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setJWTCredentialToResourceData(d, updatedJWTCredential)
@@ -140,13 +143,14 @@ func resourceKongJWTCredentialDelete(d *schema.ResourceData, meta interface{}) e
 
 	jwtCredential := getJWTCredentialFromResourceData(d)
 
-	response, error := sling.New().Path("consumers/").Path(jwtCredential.Consumer + "/").Path("jwt/").Delete(jwtCredential.ID).ReceiveSuccess(nil)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(jwtCredential.Consumer+"/").Path("jwt/").Delete(jwtCredential.ID).Receive(nil, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while deleting jwtCredential.")
 	}
 
 	if response.StatusCode != http.StatusNoContent {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	return nil

--- a/kong/resource_kong_consumer_credential_key_auth.go
+++ b/kong/resource_kong_consumer_credential_key_auth.go
@@ -54,13 +54,14 @@ func resourceKongKeyAuthCredentialCreate(d *schema.ResourceData, meta interface{
 
 	createdKeyAuthCredential := getKeyAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(keyAuthCredential).Path("consumers/").Path(keyAuthCredential.Consumer + "/").Post("key-auth/").ReceiveSuccess(createdKeyAuthCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(keyAuthCredential).Path("consumers/").Path(keyAuthCredential.Consumer+"/").Post("key-auth/").Receive(createdKeyAuthCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while creating keyAuthCredential.")
 	}
 
 	if response.StatusCode != http.StatusCreated {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setKeyAuthCredentialToResourceData(d, createdKeyAuthCredential)
@@ -73,7 +74,8 @@ func resourceKongKeyAuthCredentialRead(d *schema.ResourceData, meta interface{})
 
 	keyAuthCredential := getKeyAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().Path("consumers/").Path(keyAuthCredential.Consumer + "/").Path("key-auth/").Get(keyAuthCredential.ID).ReceiveSuccess(keyAuthCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(keyAuthCredential.Consumer+"/").Path("key-auth/").Get(keyAuthCredential.ID).Receive(keyAuthCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating keyAuthCredential.")
 	}
@@ -82,7 +84,7 @@ func resourceKongKeyAuthCredentialRead(d *schema.ResourceData, meta interface{})
 		d.SetId("")
 		return nil
 	} else if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setKeyAuthCredentialToResourceData(d, keyAuthCredential)
@@ -97,13 +99,14 @@ func resourceKongKeyAuthCredentialUpdate(d *schema.ResourceData, meta interface{
 
 	updatedKeyAuthCredential := getKeyAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(keyAuthCredential).Path("consumers/").Path(keyAuthCredential.Consumer + "/").Patch("key-auth/").Path(keyAuthCredential.ID).ReceiveSuccess(updatedKeyAuthCredential)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(keyAuthCredential).Path("consumers/").Path(keyAuthCredential.Consumer+"/").Patch("key-auth/").Path(keyAuthCredential.ID).Receive(updatedKeyAuthCredential, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating keyAuthCredential.")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setKeyAuthCredentialToResourceData(d, updatedKeyAuthCredential)
@@ -116,13 +119,14 @@ func resourceKongKeyAuthCredentialDelete(d *schema.ResourceData, meta interface{
 
 	keyAuthCredential := getKeyAuthCredentialFromResourceData(d)
 
-	response, error := sling.New().Path("consumers/").Path(keyAuthCredential.Consumer + "/").Path("key-auth/").Delete(keyAuthCredential.ID).ReceiveSuccess(nil)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("consumers/").Path(keyAuthCredential.Consumer+"/").Path("key-auth/").Delete(keyAuthCredential.ID).Receive(nil, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while deleting keyAuthCredential.")
 	}
 
 	if response.StatusCode != http.StatusNoContent {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	return nil

--- a/kong/resource_kong_key_auth_plugin.go
+++ b/kong/resource_kong_key_auth_plugin.go
@@ -75,7 +75,8 @@ func resourceKeyAuthPluginCreate(d *schema.ResourceData, meta interface{}) error
 	if plugin.API != "" {
 		request = request.Path("apis/").Path(plugin.API + "/")
 	}
-	response, error := request.Post("plugins/").ReceiveSuccess(createdPlugin)
+	errorResponse := make(map[string]interface{})
+	response, error := request.Post("plugins/").Receive(createdPlugin, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while creating plugin.")
 	}
@@ -83,7 +84,7 @@ func resourceKeyAuthPluginCreate(d *schema.ResourceData, meta interface{}) error
 	if response.StatusCode == http.StatusConflict {
 		return fmt.Errorf("409 Conflict - use terraform import to manage this plugin.")
 	} else if response.StatusCode != http.StatusCreated {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setKeyAuthPluginFromResourceData(d, createdPlugin)
@@ -96,7 +97,8 @@ func resourceKeyAuthPluginRead(d *schema.ResourceData, meta interface{}) error {
 
 	plugin := getKeyAuthPluginFromResourceData(d)
 
-	response, error := sling.New().Path("plugins/").Get(plugin.ID).ReceiveSuccess(plugin)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("plugins/").Get(plugin.ID).Receive(plugin, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating plugin.")
 	}
@@ -105,7 +107,7 @@ func resourceKeyAuthPluginRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	} else if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setKeyAuthPluginFromResourceData(d, plugin)
@@ -120,13 +122,14 @@ func resourceKeyAuthPluginUpdate(d *schema.ResourceData, meta interface{}) error
 
 	updatedPlugin := getKeyAuthPluginFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(plugin).Path("plugins/").Patch(plugin.ID).ReceiveSuccess(updatedPlugin)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().BodyJSON(plugin).Path("plugins/").Patch(plugin.ID).Receive(updatedPlugin, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while updating plugin.")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	setKeyAuthPluginFromResourceData(d, updatedPlugin)
@@ -139,13 +142,14 @@ func resourceKeyAuthPluginDelete(d *schema.ResourceData, meta interface{}) error
 
 	plugin := getKeyAuthPluginFromResourceData(d)
 
-	response, error := sling.New().Path("plugins/").Delete(plugin.ID).ReceiveSuccess(nil)
+	errorResponse := make(map[string]interface{})
+	response, error := sling.New().Path("plugins/").Delete(plugin.ID).Receive(nil, errorResponse)
 	if error != nil {
 		return fmt.Errorf("Error while deleting plugin.")
 	}
 
 	if response.StatusCode != http.StatusNoContent {
-		return fmt.Errorf(response.Status)
+		return ErrorFromResponse(response, errorResponse)
 	}
 
 	return nil


### PR DESCRIPTION
This allows the user to see the json response body hopefully preventing the need to use something outside the plugin to debug further.