### PR TITLE
Support raw JSON kong_plugin config

### DIFF
--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -114,8 +114,6 @@ func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
 		return ErrorFromResponse(response, errorResponse)
 	}
 
-	createdPlugin.Configuration = plugin.Configuration
-
 	setPluginToResourceData(d, createdPlugin)
 
 	return nil
@@ -165,8 +163,6 @@ func resourceKongPluginUpdate(d *schema.ResourceData, meta interface{}) error {
 	if response.StatusCode != http.StatusOK {
 		return ErrorFromResponse(response, errorResponse)
 	}
-
-	updatedPlugin.Configuration = plugin.Configuration
 
 	setPluginToResourceData(d, updatedPlugin)
 
@@ -219,13 +215,13 @@ func setPluginConfig(d *schema.ResourceData, config map[string]interface{}) erro
 }
 
 func getPluginConfig(d *schema.ResourceData) (map[string]interface{}, error) {
-	if config := d.Get("config"); config != nil {
+	if config, ok := d.GetOk("config"); ok {
 		return config.(map[string]interface{}), nil
 	}
 
-	if configBlob := d.Get("config_json"); configBlob != nil {
+	if configBlob, ok := d.GetOk("config_json"); ok {
 		var config map[string]interface{}
-		err := json.Unmarshal(configBlob.([]byte), config)
+		err := json.Unmarshal([]byte(configBlob.(string)), &config)
 		if err != nil {
 			return nil, err
 		}

--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -1,8 +1,10 @@
 package kong
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/dghubble/sling"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -29,11 +31,6 @@ func resourceKongPlugin() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"consumer": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -49,10 +46,34 @@ func resourceKongPlugin() *schema.Resource {
 			},
 
 			"config": &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
-				Default:  nil,
+				Type:          schema.TypeMap,
+				Optional:      true,
+				Elem:          schema.TypeString,
+				Default:       nil,
+				ConflictsWith: []string{"config_json"},
+			},
+
+			"config_json": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       nil,
+				ConflictsWith: []string{"config"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					var oldConfig map[string]interface{}
+					json.Unmarshal([]byte(old), &oldConfig)
+
+					var newConfig map[string]interface{}
+					json.Unmarshal([]byte(new), &newConfig)
+
+					return reflect.DeepEqual(oldConfig, newConfig)
+				},
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					if !json.Valid([]byte(v.(string))) {
+						errors = append(errors, fmt.Errorf("Invalid JSON: %v", v))
+					}
+
+					return
+				},
 			},
 
 			"api": &schema.Schema{
@@ -67,9 +88,15 @@ func resourceKongPlugin() *schema.Resource {
 func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
 	sling := meta.(*sling.Sling)
 
-	plugin := getPluginFromResourceData(d)
+	plugin, err := getPluginFromResourceData(d)
+	if err != nil {
+		return err
+	}
 
-	createdPlugin := getPluginFromResourceData(d)
+	createdPlugin, err := getPluginFromResourceData(d)
+	if err != nil {
+		return err
+	}
 
 	request := sling.New().BodyJSON(plugin)
 	if plugin.API != "" {
@@ -97,15 +124,9 @@ func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceKongPluginRead(d *schema.ResourceData, meta interface{}) error {
 	sling := meta.(*sling.Sling)
 
-	plugin := getPluginFromResourceData(d)
-
-	configuration := make(map[string]interface{})
-	for key, value := range plugin.Configuration {
-		configuration[key] = value
-	}
-
+	plugin := &Plugin{}
 	errorResponse := make(map[string]interface{})
-	response, error := sling.New().Path("plugins/").Get(plugin.ID).Receive(plugin, &errorResponse)
+	response, error := sling.New().Path("plugins/").Get(d.Id()).Receive(plugin, &errorResponse)
 	if error != nil {
 		return fmt.Errorf("error while updating plugin: " + error.Error())
 	}
@@ -117,8 +138,6 @@ func resourceKongPluginRead(d *schema.ResourceData, meta interface{}) error {
 		return ErrorFromResponse(response, errorResponse)
 	}
 
-	plugin.Configuration = configuration
-
 	setPluginToResourceData(d, plugin)
 
 	return nil
@@ -127,12 +146,18 @@ func resourceKongPluginRead(d *schema.ResourceData, meta interface{}) error {
 func resourceKongPluginUpdate(d *schema.ResourceData, meta interface{}) error {
 	sling := meta.(*sling.Sling)
 
-	plugin := getPluginFromResourceData(d)
+	plugin, err := getPluginFromResourceData(d)
+	if err != nil {
+		return err
+	}
 
-	updatedPlugin := getPluginFromResourceData(d)
+	updatedPlugin, err := getPluginFromResourceData(d)
+	if err != nil {
+		return err
+	}
 
 	errorResponse := make(map[string]interface{})
-	response, error := sling.New().BodyJSON(plugin).Path("plugins/").Patch(plugin.ID).Receive(updatedPlugin, &errorResponse)
+	response, error := sling.New().BodyJSON(plugin).Path("plugins/").Patch(d.Id()).Receive(updatedPlugin, &errorResponse)
 	if error != nil {
 		return fmt.Errorf("error while updating plugin: " + error.Error())
 	}
@@ -150,11 +175,8 @@ func resourceKongPluginUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongPluginDelete(d *schema.ResourceData, meta interface{}) error {
 	sling := meta.(*sling.Sling)
-
-	plugin := getPluginFromResourceData(d)
-
 	errorResponse := make(map[string]interface{})
-	response, error := sling.New().Path("plugins/").Delete(plugin.ID).Receive(nil, &errorResponse)
+	response, error := sling.New().Path("plugins/").Delete(d.Id()).Receive(nil, &errorResponse)
 	if error != nil {
 		return fmt.Errorf("error while deleting plugin: " + error.Error())
 	}
@@ -166,25 +188,79 @@ func resourceKongPluginDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func getPluginFromResourceData(d *schema.ResourceData) *Plugin {
+func setPluginConfig(d *schema.ResourceData, config map[string]interface{}) error {
+	// If a config map was specified in the schema store the raw map.
+	if _, ok := d.GetOk("config"); ok {
+		err := d.Set("config_json", nil)
+		if err != nil {
+			return fmt.Errorf("%v: Unable to set config_json to nil.", err)
+		}
+
+		return d.Set("config", config)
+	}
+
+	// Otherwise marshal the configuration map into a json blob.
+	jsonBytes, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("config", nil)
+	if err != nil {
+		return fmt.Errorf("%v: Unable to set config to nil.", err)
+	}
+
+	err = d.Set("config_json", string(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("%v: Unable to set config_json to %+v.", err, string(jsonBytes))
+	}
+
+	return nil
+}
+
+func getPluginConfig(d *schema.ResourceData) (map[string]interface{}, error) {
+	if config := d.Get("config"); config != nil {
+		return config.(map[string]interface{}), nil
+	}
+
+	if configBlob := d.Get("config_json"); configBlob != nil {
+		var config map[string]interface{}
+		err := json.Unmarshal(configBlob.([]byte), config)
+		if err != nil {
+			return nil, err
+		}
+
+		return config, nil
+	}
+
+	// No plugin configuration was specified meaning terraform-provider-kong will not manage the plugin config field.
+	return nil, nil
+}
+
+func getPluginFromResourceData(d *schema.ResourceData) (*Plugin, error) {
 	plugin := &Plugin{
-		Name:          d.Get("name").(string),
-		Configuration: d.Get("config").(map[string]interface{}),
-		API:           d.Get("api").(string),
-		Consumer:      d.Get("consumer").(string),
+		Name:     d.Get("name").(string),
+		API:      d.Get("api").(string),
+		Consumer: d.Get("consumer").(string),
 	}
 
-	if id, ok := d.GetOk("id"); ok {
-		plugin.ID = id.(string)
+	config, err := getPluginConfig(d)
+	if err != nil {
+		return nil, err
 	}
 
-	return plugin
+	if config != nil {
+		plugin.Configuration = config
+	}
+
+	return plugin, nil
 }
 
 func setPluginToResourceData(d *schema.ResourceData, plugin *Plugin) {
 	d.SetId(plugin.ID)
 	d.Set("name", plugin.Name)
-	d.Set("config", plugin.Configuration)
 	d.Set("api", plugin.API)
 	d.Set("consumer", plugin.Consumer)
+
+	setPluginConfig(d, plugin.Configuration)
 }


### PR DESCRIPTION
Create a new argument for `kong_plugin` named `config_json` which conflicts with `config`. If set it will manage plugin config as JSON. This adds support for more complex data structures such as nested lists or maps used by kong plugins such as the request-transformer plugin.

Additionally this patch causes all state to be refreshed on Read operations. Fixing `terraform refresh`.