### PR TITLE
Support enabling/disabling kong_api_plugin resources

### DIFF
--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -17,6 +17,7 @@ type Plugin struct {
 	Configuration map[string]interface{} `json:"config,omitempty"`
 	API           string                 `json:"api_id,omitempty"`
 	Consumer      string                 `json:"consumer_id,omitempty"`
+	Enabled       string                 `json:"enabled,omitempty"`
 }
 
 func resourceKongPlugin() *schema.Resource {
@@ -31,6 +32,13 @@ func resourceKongPlugin() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"enabled": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to enabled this plugin.",
+			},
+
 			"consumer": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -238,6 +246,7 @@ func getPluginFromResourceData(d *schema.ResourceData) (*Plugin, error) {
 		Name:     d.Get("name").(string),
 		API:      d.Get("api").(string),
 		Consumer: d.Get("consumer").(string),
+		Enabled:  d.Get("enabled").(string),
 	}
 
 	config, err := getPluginConfig(d)
@@ -257,6 +266,7 @@ func setPluginToResourceData(d *schema.ResourceData, plugin *Plugin) {
 	d.Set("name", plugin.Name)
 	d.Set("api", plugin.API)
 	d.Set("consumer", plugin.Consumer)
+	d.Set("enabled", plugin.Enabled)
 
 	setPluginConfig(d, plugin.Configuration)
 }


### PR DESCRIPTION
Prior to this patch this provider resource would not manage enabled/disabled status of kong plugins.